### PR TITLE
Make sure output has a log attribute

### DIFF
--- a/pkg/R/lumberjack.R
+++ b/pkg/R/lumberjack.R
@@ -153,6 +153,9 @@ stop_log <- function(data, ...){
   if ( has_log(lhs) ){
     log <- get_log(lhs)
     log$add(meta=meta, input=lhs, output=out)
+    if( !has_log(out)){
+      attr(out, LOGNAME) <- log
+    }
   }
   
   out


### PR DESCRIPTION
when I was using paste and sprintf on a character object, I found that they did not preserve the logging attribute. Adding the lines I suggested will add the logging attribute back!